### PR TITLE
Improve the scope, logging and viewing of the Biz Ops update.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -15,6 +15,7 @@ provider:
   deploymentBucket: artefacts.biz-ops-runbook-md.${env:AWS_ACCOUNT_ID}
   environment:
     BIZ_OPS_API_URL: ${env:BIZ_OPS_API_URL}
+    BIZ_OPS_URL: ${env:BIZ_OPS_URL}
     BASE_HOST: ${env:BASE_HOST}
     BASE_URL: ${env:BASE_URL}
     SCHEMA_BASE_URL: ${env:SCHEMA_BASE_URL}

--- a/src/ingestHandler.js
+++ b/src/ingestHandler.js
@@ -52,7 +52,7 @@ const ingest = async (username, userRequest) => {
 	if (!userRequest.writeToBizOps || userRequest.writeToBizOps === false) {
 		return success({
 			message:
-				'Parse & Validation Complete; Biz Ops Was NOT Updated at your request',
+				'Parse & Validation Complete. Biz Ops Was NOT Updated as you did not enable the writeToBizOps flag.',
 			details: ingestedDetails(parseResult, validationResult),
 		});
 	}

--- a/src/ingestHandler.js
+++ b/src/ingestHandler.js
@@ -8,14 +8,17 @@ const responseHeaders = {
 	'Cache-Control': 'private, no-cache, no-store, must-revalidate, max-age=0',
 };
 
-const htmlResponse = (status, message, details) => ({
-	statusCode: status,
-	body: JSON.stringify({ message, ...details }),
-	headers: responseHeaders,
-});
-const badRequestError = (message, details) =>
-	htmlResponse(400, message, details);
-const success = (message, details) => htmlResponse(200, message, details);
+const htmlResponse = ({ status, message, details }) => {
+	return {
+		statusCode: status,
+		body: JSON.stringify({ message, ...details }),
+		headers: responseHeaders,
+	};
+};
+const badRequestError = ({ message, details }) =>
+	htmlResponse({ status: 400, message, details });
+const success = ({ message, details }) =>
+	htmlResponse({ status: 200, message, details });
 
 const ingestedDetails = (parseResult, validationResult, writeResult) => ({
 	...(parseResult && {
@@ -31,33 +34,34 @@ const ingestedDetails = (parseResult, validationResult, writeResult) => ({
 
 const ingest = async (username, userRequest) => {
 	if (!userRequest.systemCode) {
-		return badRequestError('Please supply a systemCode');
+		return badRequestError({ message: 'Please supply a systemCode' });
 	}
 	if (!userRequest.content) {
-		return badRequestError('Please supply RUNBOOK.MD content');
+		return badRequestError({ message: 'Please supply RUNBOOK.MD content' });
 	}
 
 	const parseResult = await runbookMd.parseRunbookString(userRequest.content);
 	if (parseResult.errors.length) {
-		return badRequestError(
-			'Parse Failures. Please correct and resubmit',
-			ingestedDetails(parseResult),
-		);
+		return badRequestError({
+			message: 'Parse Failures. Please correct and resubmit',
+			details: ingestedDetails(parseResult),
+		});
 	}
 
 	const { json: validationResult } = await validate(parseResult.data);
 	if (!userRequest.writeToBizOps || userRequest.writeToBizOps === false) {
-		return success(
-			'Parse & Validation Complete; Biz Ops Was NOT Updated at your request',
-			ingestedDetails(parseResult, validationResult),
-		);
+		return success({
+			message:
+				'Parse & Validation Complete; Biz Ops Was NOT Updated at your request',
+			details: ingestedDetails(parseResult, validationResult),
+		});
 	}
 
 	if (!userRequest.bizOpsApiKey) {
-		return badRequestError(
-			'Unable to update Biz Ops. No API key was been provided',
-			ingestedDetails(parseResult, validationResult),
-		);
+		return badRequestError({
+			message: 'Unable to update Biz Ops. No API key was been provided',
+			details: ingestedDetails(parseResult, validationResult),
+		});
 	}
 
 	const { status: writeStatus, json: writeResult } = await updateBizOps(
@@ -66,13 +70,16 @@ const ingest = async (username, userRequest) => {
 		userRequest.systemCode,
 		parseResult.data,
 	);
-	return htmlResponse(
-		writeStatus,
-		writeStatus === 200
-			? 'Biz Ops has been updated'
-			: 'Biz Ops update failed',
-		ingestedDetails(parseResult, validationResult, writeResult),
-	);
+	return htmlResponse({
+		status: writeStatus,
+		message:
+			writeStatus === 200
+				? `Biz Ops has been updated.`
+				: `Biz Ops update failed with ${writeStatus}: ${JSON.stringify(
+						writeResult,
+				  )}`,
+		details: ingestedDetails(parseResult, validationResult, writeResult),
+	});
 };
 
 const handler = async event => {

--- a/src/lib/external-apis.js
+++ b/src/lib/external-apis.js
@@ -17,6 +17,10 @@ const callExternalApi = async ({
 	};
 	const fetchResponse = await nodeFetch(url, options);
 	if (!expectedStatuses.includes(fetchResponse.status)) {
+		logger.error(
+			{ event: `Attempt to ${method} to ${url}`, options },
+			`Failed with ${fetchResponse.status}:${fetchResponse}`,
+		);
 		throw httpError(
 			fetchResponse.status,
 			`Attempt to access ${name} ${url} ${options} failed with ${
@@ -50,7 +54,9 @@ const validate = async request =>
 	});
 
 const updateBizOps = async (username, apiKey, systemCode, content) => {
-	const queryString = `?lockFields=${Object.keys(content)
+	const queryString = `?relationshipAction=replace&lockFields=${Object.keys(
+		content,
+	)
 		.map(name => name)
 		.join(',')}`;
 	return callExternalApi({

--- a/src/templates/components/output-fields.jsx
+++ b/src/templates/components/output-fields.jsx
@@ -1,6 +1,6 @@
 const { h } = require('hyperons');
 
-const Message = ({ status, message }) => (
+const Message = ({ status, message, linkText, linkUrl }) => (
 	<div
 		className={`o-message o-message--alert ${
 			status === 200 ? 'o-message--success' : 'o-message--error'
@@ -9,9 +9,15 @@ const Message = ({ status, message }) => (
 	>
 		<div className="o-message__container">
 			<div className="o-message__content ">
-				<p />
 				<p className="o-message__content-main">{message}</p>
-				<p />
+				<div className="o-message__actions">
+					<a
+						href={`${linkUrl}`}
+						className="o-message__actions__secondary"
+					>
+						{linkText}
+					</a>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/src/templates/form-input-page.jsx
+++ b/src/templates/form-input-page.jsx
@@ -55,7 +55,22 @@ const ValidateForm = ({
 				>
 					Submit
 				</button>
-				{message ? <Message status={status} message={message} /> : null}
+				{message ? (
+					<Message
+						status={status}
+						message={message}
+						linkText={
+							status === 200
+								? 'View updated Biz Ops record'
+								: undefined
+						}
+						linkUrl={
+							status === 200
+								? `https://biz-ops-test.in.ft.com/System/${systemCode}`
+								: undefined
+						}
+					/>
+				) : null}
 				{parseErrors.length ? (
 					<ParseErrors errors={parseErrors} />
 				) : null}

--- a/src/templates/form-input-page.jsx
+++ b/src/templates/form-input-page.jsx
@@ -66,7 +66,9 @@ const ValidateForm = ({
 						}
 						linkUrl={
 							status === 200
-								? `https://biz-ops-test.in.ft.com/System/${systemCode}`
+								? `${
+										process.env.BIZ_OPS_URL
+								  }/System/${systemCode}`
 								: undefined
 						}
 					/>

--- a/src/templates/form-input-page.jsx
+++ b/src/templates/form-input-page.jsx
@@ -60,12 +60,12 @@ const ValidateForm = ({
 						status={status}
 						message={message}
 						linkText={
-							status === 200
+							status === 200 && writeToBizOps
 								? 'View updated Biz Ops record'
 								: undefined
 						}
 						linkUrl={
-							status === 200
+							status === 200 && writeToBizOps
 								? `${
 										process.env.BIZ_OPS_URL
 								  }/System/${systemCode}`

--- a/test/ingest.test.js
+++ b/test/ingest.test.js
@@ -11,7 +11,7 @@ test('Ingest is available and runs when all parameters are provided', async () =
 	expect(result.statusCode).toBe(200);
 	const body = JSON.parse(result.body);
 	expect(body.message).toBe(
-		'Parse & Validation Complete; Biz Ops Was NOT Updated at your request',
+		'Parse & Validation Complete. Biz Ops Was NOT Updated as you did not enable the writeToBizOps flag.',
 	);
 	expect(body.parseData).toHaveProperty('name', 'this is a name');
 });
@@ -38,7 +38,7 @@ test('Ingest does not fail when writeToBizOps field is omitted since the default
 	expect(result.statusCode).toBe(200);
 	const body = JSON.parse(result.body);
 	expect(body.message).toBe(
-		'Parse & Validation Complete; Biz Ops Was NOT Updated at your request',
+		'Parse & Validation Complete. Biz Ops Was NOT Updated as you did not enable the writeToBizOps flag.',
 	);
 });
 
@@ -66,7 +66,7 @@ test('Ingest does not fail when api key field is omitted if writeToBizOps is fal
 	expect(result.statusCode).toBe(200);
 	const body = JSON.parse(result.body);
 	expect(body.message).toBe(
-		'Parse & Validation Complete; Biz Ops Was NOT Updated at your request',
+		'Parse & Validation Complete. Biz Ops Was NOT Updated as you did not enable the writeToBizOps flag.',
 	);
 });
 


### PR DESCRIPTION
# Problem
Forgot to allow for relationship updates and to provide the user with direct access to the updated Biz Ops record

# Solution
Improved call to Biz Ops and improved message on Biz Ops success

# Implementation
Pass relationshipAction parameter to Biz Ops Call.
Use lambda logger to log failure in Biz Ops call.
Add Biz Ops link to the o-message that is displayed on success after biz ops write.