### PR TITLE
render markdown as HTML in validation output

### DIFF
--- a/lambdas/ingester/src/browser/_manualEntryForm.scss
+++ b/lambdas/ingester/src/browser/_manualEntryForm.scss
@@ -4,6 +4,10 @@
 		font-size: 0.8em;
 	}
 
+	code {
+		font-size: 0.9em;
+	}
+
 	p.runbook-form__submit--error {
 		display: none;
 		color: #b30000;

--- a/lambdas/ingester/src/lib/markdown-parser.js
+++ b/lambdas/ingester/src/lib/markdown-parser.js
@@ -1,0 +1,34 @@
+const marked = require('marked');
+
+// see https://marked.js.org/#/USING_ADVANCED.md#options
+// for configuration options
+marked.setOptions({
+	gfm: true,
+	breaks: false,
+	tables: true,
+});
+
+// marked wraps strings in <p></p> by defailt
+// this strips the wrapping paragraph
+// or does nothing if the string is not wrapped in <p></p>
+const stripWrappingParagraph = string => {
+	const matched = string.match(/^<p>(.*)<\/p>$/s);
+	return matched ? matched[1] : string;
+};
+
+const sanitizeHTML = string => {
+	let sanitizedHTML = string;
+	sanitizedHTML = sanitizedHTML.replace(/\n+$/s, '');
+	sanitizedHTML = stripWrappingParagraph(sanitizedHTML);
+	return sanitizedHTML;
+};
+
+exports.parseMarkdown = string => marked(string);
+
+exports.markdownToHTML = string => {
+	const html = this.parseMarkdown(string);
+	const sanitizedHTML = sanitizeHTML(html);
+	return {
+		__html: sanitizedHTML,
+	};
+};

--- a/lambdas/ingester/src/templates/components/table.jsx
+++ b/lambdas/ingester/src/templates/components/table.jsx
@@ -1,4 +1,5 @@
 const { h } = require('hyperons');
+const { markdownToHTML } = require('../../lib/markdown-parser');
 
 const List = ({ itemArray }) => itemArray.map(item => <li>{item}</li>);
 
@@ -14,7 +15,18 @@ const Cell = ({ contents, props = {} }) => {
 		return <Cell contents={contents.value} props={contents.props} />;
 	}
 	if (typeof contents === 'string') {
-		return <td {...props}>{contents}</td>;
+		// crude way of checking for markdown input
+		return /\\n|\*/.test(contents) ? (
+			<td
+				{...props}
+				// eslint-disable-next-line react/no-danger
+				dangerouslySetInnerHTML={markdownToHTML(contents)}
+			>
+				{JSON.stringify(markdownToHTML(contents))}
+			</td>
+		) : (
+			<td {...props}>{contents}</td>
+		);
 	}
 	if (typeof contents === 'boolean') {
 		return <td {...props}>{contents ? 'Yes' : 'No'}</td>;


### PR DESCRIPTION
- renders (github flavoured) markdown as HTML in validation output

An opportunity to think about how we want to store these markdown-ish values in biz-ops and...

**Before:** 
<img width="548" alt="Screenshot 2019-06-26 at 15 05 29" src="https://user-images.githubusercontent.com/12828487/60186574-fc8eb900-9823-11e9-8533-1d0f069eb322.png">
**After:**
<img width="575" alt="Screenshot 2019-06-26 at 15 05 55" src="https://user-images.githubusercontent.com/12828487/60186586-031d3080-9824-11e9-9362-579cb1d9939d.png">
---------------
**Before:**
<img width="582" alt="Screenshot 2019-06-26 at 15 05 42" src="https://user-images.githubusercontent.com/12828487/60186605-0a443e80-9824-11e9-956a-c2a88aad328c.png">
**After:**
<img width="581" alt="Screenshot 2019-06-26 at 15 06 18" src="https://user-images.githubusercontent.com/12828487/60186635-1af4b480-9824-11e9-820d-320c6a70a726.png">
---------------
**Before:**
<img width="600" alt="Screenshot 2019-06-26 at 15 05 47" src="https://user-images.githubusercontent.com/12828487/60186650-23e58600-9824-11e9-9210-cf1220c79fc5.png">
**After:**
<img width="586" alt="Screenshot 2019-06-26 at 15 06 26" src="https://user-images.githubusercontent.com/12828487/60186655-2811a380-9824-11e9-95e4-2c45021bab45.png">
